### PR TITLE
ZBUG-143 Admin Console: Last login and Description fields are missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 build/
+.idea
 .classpath
 .project
 .settings/
 /bin/
+src/java/META-INF*
+out
+zm-bulkprovision-store.iml


### PR DESCRIPTION
The search parameters were missing default timestamp and description. They have been added.
The col order will be:
zimbraAccountStatus, zimbraCOSId, description,zimbraLastLogonTimestamp,Human Timestamp (if lastlogin is available)